### PR TITLE
fix: complex var type

### DIFF
--- a/src/type/complexArray.ts
+++ b/src/type/complexArray.ts
@@ -1,12 +1,15 @@
 // An complex number element a + bj contains two numner a and b.
 class Complex {
-    public real: number = 0;
-    public virtual: number = 0;
+    constructor(
+        public real: number,
+        public virtual: number
+    ) {}
 
     public toString = () : string => {
-        return `${this.real}+${this.virtual}j`
+        return `${this.real}+${this.virtual}j`;
     }
 }
+
 class ComplexArray implements RelativeIndexable<Complex>{
     buffer: ArrayBuffer;
     offset: number = 0;
@@ -16,14 +19,10 @@ class ComplexArray implements RelativeIndexable<Complex>{
     constructor(buffer: ArrayBuffer, offset: number) {
         this.buffer = buffer;
         this.offset = offset;
-        // this.eleSize = eleSize;
 
         var temp_data = new Float64Array(buffer, offset)
         for (var i = 0; i < Math.ceil(temp_data.length / 2); i++) {
-            const ele: Complex = {
-                real: temp_data[2*i],
-                virtual: temp_data[2*i+1]
-            }
+            const ele: Complex = new Complex(temp_data[2*i], temp_data[2*i+1]);
             this.data.push(ele);
         }
     }


### PR DESCRIPTION
# Complex number support

A complex number in `numpy` uses two `float64` to represent (c16), the first is real part and the second is virtual part.